### PR TITLE
fix: fix editor not loading with sub path

### DIFF
--- a/src/components/TextEditor/index.tsx
+++ b/src/components/TextEditor/index.tsx
@@ -9,7 +9,7 @@ import textEditorDeclarations from './declarations';
 // https://github.com/suren-atoyan/monaco-react#loader-config
 loader.config({
   paths: {
-    vs: '/public/plugins/gapit-htmlgraphics-panel/lib/vs',
+    vs: 'public/plugins/gapit-htmlgraphics-panel/lib/vs',
   },
 });
 


### PR DESCRIPTION
The leading slash causes the monacco editor to not load.