### PR TITLE
feat: centralize execution environment variables

### DIFF
--- a/src/HTMLPanel.tsx
+++ b/src/HTMLPanel.tsx
@@ -94,6 +94,21 @@ export class HTMLPanel extends PureComponent<Props, PanelState> {
     const data = dynamic ? this.data : this.props.data;
     const codeData = this.getCodeData();
 
+    const htmlNode = this.state.shadowContainerRef.current?.firstElementChild?.shadowRoot as HTMLNodeElement;
+    const options = this.props.options;
+    const theme = config.theme;
+
+    const htmlGraphics = {
+      htmlNode,
+      data,
+      customProperties: codeData,
+      codeData,
+      options,
+      theme,
+      getTemplateSrv,
+      getLocationSrv,
+    };
+
     const F = new Function(
       'htmlNode',
       'data',
@@ -103,18 +118,10 @@ export class HTMLPanel extends PureComponent<Props, PanelState> {
       'theme',
       'getTemplateSrv',
       'getLocationSrv',
+      'htmlGraphics',
       script
     );
-    F(
-      this.state.shadowContainerRef.current?.firstElementChild?.shadowRoot,
-      data,
-      codeData,
-      codeData,
-      this.props.options,
-      config.theme,
-      getTemplateSrv,
-      getLocationSrv
-    );
+    F(htmlNode, data, codeData, codeData, options, theme, getTemplateSrv, getLocationSrv, htmlGraphics);
   }
 
   onRender() {

--- a/src/components/TextEditor/declarations/htmlGraphics.ts
+++ b/src/components/TextEditor/declarations/htmlGraphics.ts
@@ -1,0 +1,12 @@
+export default `
+declare const htmlGraphics: {
+  codeData: typeof codeData;
+  customProperties: typeof customProperties;
+  data: typeof data;
+  getLocationSrv: typeof getLocationSrv;
+  getTemplateSrv: typeof getTemplateSrv;
+  htmlNode: typeof htmlNode;
+  options: typeof options;
+  theme: typeof theme;
+};
+`;

--- a/src/components/TextEditor/declarations/index.ts
+++ b/src/components/TextEditor/declarations/index.ts
@@ -7,6 +7,7 @@ import dataQueryRequest from './dataQueryRequest';
 import fieldColor from './fieldColor';
 import getLocationSrv from './getLocationSrv';
 import getTemplateSrv from './getTemplateSrv';
+import htmlGraphics from './htmlGraphics';
 import htmlNode from './htmlNode';
 import options from './options';
 import scopedVars from './scopedVars';
@@ -30,4 +31,5 @@ export default codeData +
   theme +
   thresholds +
   timeRanges +
-  valueMapping;
+  valueMapping +
+  htmlGraphics;

--- a/src/components/TextEditor/declarations/textEditorDeclarations.test.ts
+++ b/src/components/TextEditor/declarations/textEditorDeclarations.test.ts
@@ -5,7 +5,7 @@ describe('Text editor declarations', () => {
     expect(textEditorDeclarations).toEqual(expect.any(String));
   });
   describe('Contains the needed declarations', () => {
-    it('contains htmlNode', () => {
+    it('contains execution environment variables', () => {
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const htmlNode'));
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const data'));
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const codeData'));
@@ -14,6 +14,7 @@ describe('Text editor declarations', () => {
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const theme'));
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const getTemplateSrv'));
       expect(textEditorDeclarations).toEqual(expect.stringContaining('declare function getLocationSrv'));
+      expect(textEditorDeclarations).toEqual(expect.stringContaining('declare const htmlGraphics'));
     });
   });
 });


### PR DESCRIPTION
Copy the exisiting execution environment variables into htmlGraphics.
This is to not make too many global variables.
The old variables is not removed to keep backwards compatibility.