### PR TITLE
fix: fix shadow container not removing all children

### DIFF
--- a/src/HTMLPanel.tsx
+++ b/src/HTMLPanel.tsx
@@ -197,8 +197,8 @@ export class HTMLPanel extends PureComponent<Props, PanelState> {
     const shadowContainerElt = this.state.shadowContainerRef.current;
 
     if (shadowContainerElt) {
-      if (shadowContainerElt.firstChild) {
-        shadowContainerElt.removeChild(shadowContainerElt.firstChild);
+      while (shadowContainerElt.firstChild) {
+        shadowContainerElt.firstChild.remove();
       }
 
       shadowContainerElt.appendChild(this.createShadowRootElement());


### PR DESCRIPTION
Since the rootCSS adds an element,
there are more than one element in the shadow container.
Removing all children will fix a problem where htmlNode doesn't exist.