### PR TITLE
Feature: Only load declarations in edit mode

### DIFF
--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
 import { EditorLanguageType } from 'types';
 import { CodeEditor as GrafanaCodeEditor, Monaco } from '@grafana/ui';
-import declarations from './declarations';
 
 interface Props {
   language: EditorLanguageType;
@@ -14,7 +13,9 @@ export const CodeEditor: FC<Props> = ({ language, value, onChange }) => {
   const editorDidMount = (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
     if (language === 'javascript') {
       // Add autocompletion for panel definitions (htmlNode, codeData, data, options, ETC)
-      monaco.languages.typescript.javascriptDefaults.addExtraLib(declarations, 'HtmlGraphics/HtmlGraphics.d.ts');
+      import('./declarations').then(({ default: _ }) => {
+        monaco.languages.typescript.javascriptDefaults.addExtraLib(_, 'HtmlGraphics/HtmlGraphics.d.ts');
+      });
     }
   };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports.getWebpackConfig = (config, options) => ({
+  ...config,
+  output: {
+    ...config.output,
+    publicPath: 'public/plugins/gapit-htmlgraphics-panel/',
+  },
+});


### PR DESCRIPTION
Because of this issue https://github.com/grafana/grafana/issues/40671,
the publicPath needs to be set to the plugin path.

Closes #48