### PR TITLE
docs: wrap variables used by the panel

### DIFF
--- a/website/docs/examples/update-grafana-variable-example.md
+++ b/website/docs/examples/update-grafana-variable-example.md
@@ -4,6 +4,11 @@ title: Update grafana variable example
 ---
 
 ![Update grafana variable example](../../static/gif/update-grafana-variable-example.gif)
+
+:::caution
+For Grafana v8.3.0+ variables used by HTMLGraphics won't update when the variable is changed unless it's wrapped in `${}`.
+:::
+
 ![testVariable used](../../static/img/test-variable-used.png)
 
 `HTML/SVG`
@@ -15,7 +20,9 @@ title: Update grafana variable example
 `onInit`
 
 ```javascript
-const VARIABLE_NAME = 'testVariable';
+// For Grafana v8.3.0+ the variable needs to be wrapped in ${}
+const { testVariable } = customProperties;
+const testVariableName = testVariable.replace(/[${}]/g, '');
 const buttonElt = htmlNode.querySelector('button');
 
 /*
@@ -34,16 +41,16 @@ function updateGrafanaVariable(variableName, value) {
   });
 }
 
-function getGrafanaVariableValue(variableName) {
-  return getTemplateSrv().replace(`$${variableName}`);
+function getGrafanaVariableValue(variable) {
+  return getTemplateSrv().replace(variable);
 }
 
 function updateButtonText() {
-  buttonElt.textContent = `${VARIABLE_NAME}'s current value is: ${getGrafanaVariableValue(VARIABLE_NAME)}`;
+  buttonElt.textContent = `${testVariableName}'s current value is: ${getGrafanaVariableValue(testVariable)}`;
 }
 
 buttonElt.onclick = function () {
-  updateGrafanaVariable(VARIABLE_NAME, getGrafanaVariableValue(VARIABLE_NAME) == 'b' ? 'a' : 'b');
+  updateGrafanaVariable(testVariableName, getGrafanaVariableValue(testVariable) == 'b' ? 'a' : 'b');
 };
 
 /*
@@ -55,21 +62,56 @@ htmlNode.addEventListener('panelupdate', () => {
 });
 ```
 
+`Custom properties`
+
+```json
+{
+  "testVariable": "${testVariable}"
+}
+```
+
 `Panel options` (import/export)
 
 ```json
 {
+  "calcsMutation": "standard",
+  "reduceOptions": {
+    "calcs": [
+      "lastNotNull",
+      "last",
+      "first",
+      "firstNotNull",
+      "min",
+      "max",
+      "mean",
+      "sum",
+      "count",
+      "range",
+      "delta",
+      "step",
+      "diff",
+      "logmin",
+      "allIsZero",
+      "allIsNull",
+      "diffperc"
+    ]
+  },
   "add100Percentage": true,
   "centerAlignContent": true,
   "overflow": "visible",
   "SVGBaseFix": true,
-  "codeData": "{\n  \"text\": \"Random text\"\n}",
+  "codeData": "{\n  \"testVariable\": \"${testVariable}\"\n}",
+  "rootCSS": "",
   "css": "",
-  "html": "<button>Update variable</button>\n",
+  "html": "<button></button>\n",
   "renderOnMount": true,
   "onRender": "",
   "dynamicData": false,
+  "dynamicHtmlGraphics": false,
+  "dynamicFieldDisplayValues": false,
+  "dynamicProps": false,
   "panelupdateOnMount": true,
-  "onInit": "const VARIABLE_NAME = 'testVariable';\nconst buttonElt = htmlNode.querySelector('button');\n\n/*\n  Update a grafana variable\n\n  More information in the grafana docs\n  https://grafana.com/docs/grafana/latest/developers/plugins/add-support-for-variables/\n*/\nfunction updateGrafanaVariable(variableName, value) {\n  getLocationSrv().update({\n    query: {\n      [`var-${variableName}`]: value,\n    },\n    partial: true, // partial: true makes the update only affect the query parameters listed in query, and leaves the other query parameters unchanged.\n    replace: true, // replace: true tells Grafana to update the current URL state, rather than creating a new history entry.\n  });\n}\n\nfunction getGrafanaVariableValue(variableName) {\n  return getTemplateSrv().replace(`$${variableName}`);\n}\n\nfunction updateButtonText() {\n  buttonElt.textContent = `${VARIABLE_NAME}'s current value is: ${getGrafanaVariableValue(VARIABLE_NAME)}`;\n}\n\nbuttonElt.onclick = function () {\n  updateGrafanaVariable(VARIABLE_NAME, getGrafanaVariableValue(VARIABLE_NAME) == 'b' ? 'a' : 'b');\n};\n\n/*\n  When the variable changes panelupdate will trigger.\n  The panelupdate is used to update the button text so the text is the same as the variable.\n*/\nhtmlNode.addEventListener('panelupdate', () => {\n  updateButtonText();\n});"
+  "onInitOnResize": false,
+  "onInit": "// For Grafana v8.3.0+ the variable needs to be wrapped in ${}\nconst { testVariable } = customProperties;\nconst testVariableName = testVariable.replace(/[${}]/g, \"\");\nconst buttonElt = htmlNode.querySelector('button');\n\n/*\n  Update a grafana variable\n\n  More information in the grafana docs\n  https://grafana.com/docs/grafana/latest/developers/plugins/add-support-for-variables/\n*/\nfunction updateGrafanaVariable(variableName, value) {\n  getLocationSrv().update({\n    query: {\n      [`var-${variableName}`]: value,\n    },\n    partial: true, // partial: true makes the update only affect the query parameters listed in query, and leaves the other query parameters unchanged.\n    replace: true, // replace: true tells Grafana to update the current URL state, rather than creating a new history entry.\n  });\n}\n\nfunction getGrafanaVariableValue(variable) {\n  return getTemplateSrv().replace(variable);\n}\n\nfunction updateButtonText() {\n  buttonElt.textContent = `${testVariableName}'s current value is: ${getGrafanaVariableValue(testVariable)}`;\n}\n\nbuttonElt.onclick = function () {\n  updateGrafanaVariable(testVariableName, getGrafanaVariableValue(testVariable) == 'b' ? 'a' : 'b');\n};\n\n/*\n  When the variable changes panelupdate will trigger.\n  The panelupdate is used to update the button text so the text is the same as the variable.\n*/\nhtmlNode.addEventListener('panelupdate', () => {\n  updateButtonText();\n});\n"
 }
 ```


### PR DESCRIPTION
For Grafana v8.3.0+ variables used by HTMLGraphics won't update
when the variable is changed unless it's wrapped in ${}
Caused by https://github.com/grafana/grafana/pull/39420