### PR TITLE
feat: dynamically update type declarations

### DIFF
--- a/src/components/CodeEditor/declarations/customProperties.d.ts
+++ b/src/components/CodeEditor/declarations/customProperties.d.ts
@@ -1,0 +1,7 @@
+type JSONObject = {
+  [key in string]: JSONValue;
+};
+type JSONValue = string | number | boolean | null | JSONObject | JSONValue[];
+type JSONType = JSONObject | JSONValue[];
+
+export type CustomProperties = JSONType;

--- a/src/components/CodeEditor/declarations/global.d.ts
+++ b/src/components/CodeEditor/declarations/global.d.ts
@@ -12,7 +12,8 @@ import {
   getTemplateSrv as getTemplateSrvType,
   LocationService,
 } from '@grafana/runtime';
-import { HTMLNode, JSONType, OptionsInterface, PopulatedGetFieldDisplayValuesOptions } from './index';
+import { HTMLNode, OptionsInterface, PopulatedGetFieldDisplayValuesOptions } from './index';
+import type { CustomProperties } from './customProperties';
 
 declare global {
   /**
@@ -24,11 +25,11 @@ declare global {
    *
    * @deprecated in favor of {@link customProperties}
    */
-  const codeData: JSONType;
+  const codeData: CustomProperties;
   /**
    * The parsed JSON object from the Custom properties option.
    */
-  const customProperties: typeof codeData;
+  const customProperties: CustomProperties;
   /**
    * The PanelData interface passed into the panel by Grafana.
    */

--- a/src/components/CodeEditor/declarations/index.d.ts
+++ b/src/components/CodeEditor/declarations/index.d.ts
@@ -44,12 +44,6 @@ export interface HTMLNode extends ShadowRoot {
   onpanelwillunmount: () => void;
 }
 
-export type JSONObject = {
-  [key in string]: JSONValue;
-};
-export type JSONValue = string | number | boolean | null | JSONObject | JSONValue[];
-export type JSONType = JSONObject | JSONValue[];
-
 export interface PopulatedGetFieldDisplayValuesOptions {
   series?: GetFieldDisplayValuesOptions['data'];
   reduceOptions?: GetFieldDisplayValuesOptions['reduceOptions'];


### PR DESCRIPTION
The customProperties/codeData type declarations in onInit and onRender are now dynamically updated based on the json data written in the customProperties section.
This only works for Grafana v8.2.0-v8.3.X and v9.2.0 and later. Grafana v8.4.0 updated monaco editor to v0.31.1 which had a bug which prevents dynamically updating type declarations. This was fixed in Grafana v9.2.0.

![image](https://github.com/user-attachments/assets/42d806fa-9bb8-40f3-80f4-3fce2754ed2a)

![image](https://github.com/user-attachments/assets/637ebef6-a281-466b-881f-a651360c488b)

Closes #116 