### PR TITLE
feat: add adjustable height for the code editor

### DIFF
--- a/src/components/CodeEditor/HeightControllerBar.tsx
+++ b/src/components/CodeEditor/HeightControllerBar.tsx
@@ -1,0 +1,118 @@
+import React, { type RefObject } from 'react';
+import { css } from '@emotion/css';
+import { IconButton, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import type { GrafanaTheme2 } from '@grafana/data';
+
+function getShrinkIcon(
+  editorHeight: number | undefined,
+  containerHeight: number | undefined,
+  viewHeight33InPx: number
+) {
+  if (editorHeight === undefined || containerHeight === undefined) {
+    return 'arrow-up';
+  }
+  if (editorHeight === 64) {
+    return 'arrow-left';
+  }
+  if (editorHeight < 64) {
+    return 'arrow-down';
+  }
+  if (viewHeight33InPx < Math.round(containerHeight)) {
+    return 'angle-double-up';
+  }
+  return 'arrow-up';
+}
+
+function getExpandIcon(
+  editorHeight: number | undefined,
+  containerHeight: number | undefined,
+  viewHeight33InPx: number
+) {
+  if (editorHeight === undefined || containerHeight === undefined) {
+    return 'arrow-down';
+  }
+  if (viewHeight33InPx === Math.round(containerHeight)) {
+    return 'arrow-left';
+  }
+  if (viewHeight33InPx < Math.round(containerHeight)) {
+    return 'arrow-up';
+  }
+  if (editorHeight < 64) {
+    return 'angle-double-down';
+  }
+  return 'arrow-down';
+}
+
+export function HeightControllerBar({
+  containerRef,
+  editorHeight,
+  containerHeight,
+}: {
+  containerRef: RefObject<HTMLDivElement>;
+  editorHeight: number | undefined;
+  containerHeight: number | undefined;
+}) {
+  const styles = useStyles2(getStyles);
+
+  const viewHeight33InPx = Math.round(window.innerHeight * 0.33);
+  const editorHeightOffset = (containerHeight && editorHeight && containerHeight - editorHeight) ?? 0;
+
+  const shrinkIcon = getShrinkIcon(editorHeight, containerHeight, viewHeight33InPx);
+  const expandIcon = getExpandIcon(editorHeight, containerHeight, viewHeight33InPx);
+
+  const actuallySetContainerHeight = (height: string) => {
+    if (!containerRef.current) {
+      return;
+    }
+    containerRef.current.style.height = height;
+  };
+
+  return (
+    <div className={styles.bar}>
+      <Tooltip content={'Height of the code editor'}>
+        <div>
+          <Text variant="bodySmall">
+            {editorHeight === 5 ? '(min) ' : ''}
+            {editorHeight === 64 ? '(default) ' : ''}
+            {editorHeight !== undefined ? editorHeight.toFixed() + 'px' : ''}
+          </Text>
+        </div>
+      </Tooltip>
+      <div className={styles.heightText}>
+        <IconButton
+          aria-label="Set editor height to 64px"
+          tooltip="Set editor height to 64px"
+          name={shrinkIcon}
+          size="md"
+          onClick={() => actuallySetContainerHeight(`${64 + editorHeightOffset}px`)}
+        />
+        <IconButton
+          aria-label="Set editor height to 33vh"
+          tooltip={`Set editor height to 33vh (${viewHeight33InPx - editorHeightOffset}px)`}
+          name={expandIcon}
+          size="md"
+          onClick={() => actuallySetContainerHeight('33vh')}
+        />
+      </div>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    bar: css`
+      display: flex;
+      align-items: center;
+      justify-content: end;
+      padding-right: 14px;
+      gap: 8px;
+      border: 1px solid ${theme.colors.border.weak};
+      border-top: none;
+    `,
+    heightText: css`
+      height: 24px;
+      display: flex;
+      gap: 4px;
+    `,
+  };
+}


### PR DESCRIPTION
The height is adjusted with the "resize" css style. Most browsers support it, but some, like Safari, do not.

The default height is also lowered to 64px mainly to make scrolling easier.
I also found it a lot easier to get an overview and navigate through the options with the smaller editor height :D

![Peek 2025-06-16 12-38](https://github.com/user-attachments/assets/c28c713d-2065-4262-8481-77be79444420)

Isn't exactly what's asked in #179, but does make it easier to scroll passed the onRender block, so I will consider it solves the same problem.

Closes #179