### PR TITLE
fix: replace small file upload button

### DIFF
--- a/src/components/PanelOptions/ImportExport.tsx
+++ b/src/components/PanelOptions/ImportExport.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StandardEditorProps } from '@grafana/data';
 import { CodeEditorOptionSettings } from 'types';
 import { CodeEditor } from 'components/CodeEditor';
-import { Button, Input } from '@grafana/ui';
+import { Button, FileUpload } from '@grafana/ui';
 import { exportFile, contentType } from 'utils/exportFile';
 import { readFile } from 'utils/readFile';
 
@@ -48,7 +48,7 @@ export const ImportExportOption: React.FC<Props> = ({ value, item, onChange, con
 
   return (
     <div>
-      <Input type="file" onChange={(e) => importPanelOptions(e.currentTarget.files)} />
+      <FileUpload onFileUpload={(e) => importPanelOptions(e.currentTarget.files)} showFileName accept=".json" />
       <Spacer />
       <CodeEditor settings={item.settings} value={getOptionsString()} context={context} onChange={updatePanelOptions} />
       <Spacer />


### PR DESCRIPTION
For some reason an input with type="file" has a height of 4px. https://github.com/grafana/grafana/blob/01ec8e3a4aa74ae730281876031a2a97f85bf2cb/packages/grafana-data/src/themes/createComponents.ts#L90 https://github.com/grafana/grafana/blob/0c016e210ad39502253e02f35c65ff6721eb0736/packages/grafana-ui/src/themes/GlobalStyles/forms.ts#L38

Now uses the FileUpload component which has a normal height :D

Before (long tiny 4px button):
<img width="313" height="200" alt="image" src="https://github.com/user-attachments/assets/007b4e0d-70a1-4566-9327-922a4b1f85da" />


After:
<img width="313" height="200" alt="image" src="https://github.com/user-attachments/assets/da94ba5d-002c-4943-9527-559993849169" />
