### PR TITLE
fix: don't shrink edit panel on file upload

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import type { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+interface Props {
+  onFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  accept?: string;
+}
+
+export const FileUpload = ({ onFileUpload, accept }: Props) => {
+  const styles = useStyles2(getStyles());
+
+  return (
+    <>
+      <input
+        type="file"
+        style={{
+          // Use css styles instead of emotion classes to override the styles set by Grafana (for some reason they have higher priority)
+          height: 'auto', // override: https://github.com/grafana/grafana/blob/563109b696e9c1cbaf345f2ab7a11f7f78422982/packages/grafana-ui/src/themes/GlobalStyles/forms.ts#L39
+          lineHeight: '1', // override: https://github.com/grafana/grafana/blob/563109b696e9c1cbaf345f2ab7a11f7f78422982/packages/grafana-ui/src/themes/GlobalStyles/forms.ts#L42
+          width: '100%', // override: https://github.com/grafana/grafana/blob/563109b696e9c1cbaf345f2ab7a11f7f78422982/packages/grafana-ui/src/themes/GlobalStyles/forms.ts#L66
+        }}
+        onChange={onFileUpload}
+        accept={accept}
+        className={styles.input}
+      />
+    </>
+  );
+};
+
+const getStyles = () => (theme: GrafanaTheme2) => {
+  return {
+    input: css({
+      padding: theme.spacing(2),
+    }),
+  };
+};

--- a/src/components/PanelOptions/ImportExport.tsx
+++ b/src/components/PanelOptions/ImportExport.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { StandardEditorProps } from '@grafana/data';
 import { CodeEditorOptionSettings } from 'types';
 import { CodeEditor } from 'components/CodeEditor';
-import { Button, FileUpload } from '@grafana/ui';
+import { Button } from '@grafana/ui';
 import { exportFile, contentType } from 'utils/exportFile';
 import { readFile } from 'utils/readFile';
+import { FileUpload } from 'components/FileUpload';
 
 interface Props extends StandardEditorProps<string, CodeEditorOptionSettings> {}
 
@@ -48,7 +49,7 @@ export const ImportExportOption: React.FC<Props> = ({ value, item, onChange, con
 
   return (
     <div>
-      <FileUpload onFileUpload={(e) => importPanelOptions(e.currentTarget.files)} showFileName accept=".json" />
+      <FileUpload onFileUpload={(e) => importPanelOptions(e.currentTarget.files)} accept=".json" />
       <Spacer />
       <CodeEditor settings={item.settings} value={getOptionsString()} context={context} onChange={updatePanelOptions} />
       <Spacer />


### PR DESCRIPTION
The first attempt was: https://github.com/gapitio/gapit-htmlgraphics-panel/pull/210 but it had an annoying issue with the edit panel being shrunk after clicking the file upload button.

Now just use the normal input element... :(

Before:

[Screencast_20251105_083440.webm](https://github.com/user-attachments/assets/cb8c1886-4c0d-465b-9795-49ab120fd790)

<img width="493" height="670" alt="image" src="https://github.com/user-attachments/assets/53b6a7df-15b5-4083-87e6-20052873f8e1" />

After:
<img width="493" height="670" alt="image" src="https://github.com/user-attachments/assets/3a8bec6d-85c5-4f16-9260-938dd4082324" />